### PR TITLE
Support or syntax

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Paulo Reis <paulovitin@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ To add an ``active`` CSS class to a link when the request path matches a given v
 
     <a href="{% url 'view-name' %}" class="{% active_link 'view-name' %}">Menu item</a>
 
-If you has a sub-menu or tabs and needs they be active and your parent too, you can use ``OR`` to check this:
+If you has a sub-menu or tabs and needs they be active and parent too, you can use ``||`` to check this:
 
 .. code-block:: html
 

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,13 @@ To add an ``active`` CSS class to a link when the request path matches a given v
 
     <a href="{% url 'view-name' %}" class="{% active_link 'view-name' %}">Menu item</a>
 
+If you has a sub-menu or tabs and needs they be active and your parent too, you can use ``OR`` to check this:
+
+.. code-block:: html
+
+    <a href="{% url 'view-name' %}" class="{% active_link 'view-name || view-sub-name' %}">Menu Item</a>
+    <a href="{% url 'view-sub-name' %}" class="{% active_link 'view-sub-name' %}">Tab Item</a>
+
 You can also use a custom CSS class:
 
 .. code-block:: html

--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -11,11 +11,11 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def active_link(context, viewname, css_class=None, strict=None, *args, **kwargs):
+def active_link(context, viewnames, css_class=None, strict=None, *args, **kwargs):
     """
     Renders the given CSS class if the request path matches the path of the view.
     :param context: The context where the tag was called. Used to access the request object.
-    :param viewname: The name of the view (include namespaces if any).
+    :param viewnames: The name of the view or views separated by || (include namespaces if any).
     :param css_class: The CSS class to render.
     :param strict: If True, the tag will perform an exact match with the request path.
     :return:
@@ -30,12 +30,19 @@ def active_link(context, viewname, css_class=None, strict=None, *args, **kwargs)
     if request is None:
         # Can't work without the request object.
         return ''
-    path = reverse(viewname, args=args, kwargs=kwargs)
-    request_path = escape_uri_path(request.path)
-    if strict:
-        active = request_path == path
-    else:
-        active = request_path.find(path) == 0
+    active = False
+    views = viewnames.split('||')
+    for viewname in views:
+        path = reverse(viewname.strip(), args=args, kwargs=kwargs)
+        request_path = escape_uri_path(request.path)
+        if strict:
+            active = request_path == path
+        else:
+            active = request_path.find(path) == 0
+        if active:
+            break
+
     if active:
         return css_class
+
     return ''

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -22,4 +22,9 @@ To add an `active` CSS class to a link when the request path matches a given vie
 
     <a href="{% url 'view-name' %}" class="{% active_link 'view-name' %}">Menu item</a>
 
+If you has a sub-menu or tabs and needs they be active and your parent too, you can use ``||`` to check this:
+
+    <a href="{% url 'view-name' %}" class="{% active_link 'view-name || view-sub-name' %}">Menu Item</a>
+    <a href="{% url 'view-sub-name' %}" class="{% active_link 'view-sub-name' %}">Tab Item</a>
+
 Replace `view-name` with the name of your view (including namespaces).

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -26,6 +26,18 @@ class TestActiveLink(TestCase):
         html = template.render(context)
         assert 'active' in html
 
+    def test_match_defaults_with_multiple_view_name(self):
+        template = Template("""
+            {% load active_link_tags %}
+            {% active_link 'simple || multiple' %}
+        """)
+        context0 = Context({'request': self.client.get('/simple/')})
+        context1 = Context({'request': self.client.get('/multiple/')})
+        html0 = template.render(context0)
+        html1 = template.render(context1)
+        assert 'active' in html0
+        assert 'active' in html1
+
     def test_match_not_strict(self):
         template = Template("""
             {% load active_link_tags %}
@@ -39,6 +51,15 @@ class TestActiveLink(TestCase):
         template = Template("""
             {% load active_link_tags %}
             {% active_link 'simple-action' %}
+        """)
+        context = Context({'request': self.client.get('/other/action/')})
+        html = template.render(context)
+        assert 'active' not in html
+
+    def test_no_match_not_strict_with_multiple_view_name(self):
+        template = Template("""
+            {% load active_link_tags %}
+            {% active_link 'simple-action || multiple-action' %}
         """)
         context = Context({'request': self.client.get('/other/action/')})
         html = template.render(context)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -7,7 +7,9 @@ from django.views.generic import View
 
 urlpatterns = [
     url(r'^simple/$', View.as_view(), name='simple'),
+    url(r'^multiple/$', View.as_view(), name='multiple'),
     url(r'^simple/action/$', View.as_view(), name='simple-action'),
+    url(r'^multiple/action/$', View.as_view(), name='multiple-action'),
     url(r'^other/action/$', View.as_view(), name='other-action'),
     url(r'^detailed/action/(?P<pk>[0-9]+)/$', View.as_view(), name='detailed-action')
 ]


### PR DESCRIPTION
**Why**
Sometimes you has a menu and a tab menu in internal page, and you need check the tab menu and the parent menu.

**How**
Add to the view-names string a support to **|| (two pipes)**, we can write checks like bellow:
```html
<a class="{% active_link 'view-tab-one || view-tab-two' %}">Menu</a>
<a class="{% active_link 'view-tab-one' %}">Tab One</a>
```