### PR TITLE
Add support for specifying inactive class

### DIFF
--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -11,12 +11,13 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
-def active_link(context, viewnames, css_class=None, strict=None, *args, **kwargs):
+def active_link(context, viewnames, css_class=None, inactive_class='', strict=None, *args, **kwargs):
     """
     Renders the given CSS class if the request path matches the path of the view.
     :param context: The context where the tag was called. Used to access the request object.
     :param viewnames: The name of the view or views separated by || (include namespaces if any).
     :param css_class: The CSS class to render.
+    :param inactive_class: The CSS class to render if the views is not active.
     :param strict: If True, the tag will perform an exact match with the request path.
     :return:
     """
@@ -48,4 +49,4 @@ def active_link(context, viewnames, css_class=None, strict=None, *args, **kwargs
     if active:
         return css_class
 
-    return ''
+    return inactive_class


### PR DESCRIPTION
Imagine a scenario where you would like to _remove_ a class when a route is active.  For example, I may have a vertical navbar with a collapsable sub-menu:

```
- Link 1
- Link 2
- Sublinks
    - Sublink 1
    - Sublink 2
```

If using Bootstrap 4's [Collapse features](https://getbootstrap.com/docs/4.0/components/collapse/), I would want to collapse the "Sublinks" menu when we're not on any of the sublink routes.  To do this, I would want the `collapse` class to be present when the route is _not_ active.  However, when I navigate to Sublink 1 or Sublink 2, I would want to remove the `collapse` class so the link menu in the navbar is not collapsed when the menu is rendered.