### PR TITLE
Fixed to work with 404 pages

### DIFF
--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -42,13 +42,13 @@ def active_link(
     resolver_kwargs = {}
     if hasattr(request, "resolver_match") and hasattr(request.resolver_match, "kwargs"):
         resolver_kwargs = request.resolver_match.kwargs
-    
+
     kwargs.update(resolver_kwargs)
 
     active = False
     views = viewnames.split("||")
     request_path = escape_uri_path(request.path)
-    
+
     for viewname in views:
         try:
             path = reverse(viewname.strip(), args=args, kwargs=kwargs)

--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -39,8 +39,10 @@ def active_link(
         # Can't work without the request object.
         return css_inactive_class
 
-    resolver_kwargs = getattr(request, 'resolver_match', None)
-    resolver_kwargs = getattr(resolver_kwargs, 'kwargs', {}) if resolver_kwargs else {}
+    resolver_kwargs = {}
+    if hasattr(request, 'resolver_match') and hasattr(request.resolver_match, 'kwargs'):
+        resolver_kwargs = request.resolver_match.kwargs
+
     kwargs.update(resolver_kwargs)
 
     active = False

--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -39,23 +39,24 @@ def active_link(
         # Can't work without the request object.
         return css_inactive_class
 
-    if request.resolver_match.kwargs != {}:
-        # Capture the url kwargs to reverse against
-        kwargs.update(request.resolver_match.kwargs)
+    resolver_kwargs = getattr(request, 'resolver_match', None)
+    resolver_kwargs = getattr(resolver_kwargs, 'kwargs', {}) if resolver_kwargs else {}
+    kwargs.update(resolver_kwargs)
 
     active = False
     views = viewnames.split("||")
+    request_path = escape_uri_path(request.path)
 
     for viewname in views:
         try:
             path = reverse(viewname.strip(), args=args, kwargs=kwargs)
         except NoReverseMatch:
             continue
-        request_path = escape_uri_path(request.path)
+        
         if strict:
             active = request_path == path
         else:
-            active = request_path.find(path) == 0
+            active = request_path.startswith(path) or path.startswith(request_path)
         if active:
             break
 

--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -40,21 +40,21 @@ def active_link(
         return css_inactive_class
 
     resolver_kwargs = {}
-    if hasattr(request, 'resolver_match') and hasattr(request.resolver_match, 'kwargs'):
+    if hasattr(request, "resolver_match") and hasattr(request.resolver_match, "kwargs"):
         resolver_kwargs = request.resolver_match.kwargs
-
+    
     kwargs.update(resolver_kwargs)
 
     active = False
     views = viewnames.split("||")
     request_path = escape_uri_path(request.path)
-
+    
     for viewname in views:
         try:
             path = reverse(viewname.strip(), args=args, kwargs=kwargs)
         except NoReverseMatch:
             continue
-        
+
         if strict:
             active = request_path == path
         else:


### PR DESCRIPTION
The django-active-link doesn't work in a 404 template primarily because of how Django handles 404 errors and the context available during these errors. 

This fix:
* Handle cases where request might be None more gracefully.
* Safely access resolver_match and its kwargs, falling back to an empty dict if not available.
* Continue the loop if a NoReverseMatch exception occurs, allowing other viewnames to be checked.
* The path comparison is now more flexible, checking if either path starts with the other.