### PR TITLE
fix: Explicit kwargs should take precedence over resolver_kwargs

### DIFF
--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -43,7 +43,8 @@ def active_link(
     if hasattr(request, "resolver_match") and hasattr(request.resolver_match, "kwargs"):
         resolver_kwargs = request.resolver_match.kwargs
 
-    kwargs.update(resolver_kwargs)
+    # Use resolver_kwargs as defaults, but explicitly provided kwargs (like pk) take precedence
+    kwargs = {**resolver_kwargs, **kwargs}
 
     active = False
     views = viewnames.split("||")

--- a/active_link/templatetags/active_link_tags.py
+++ b/active_link/templatetags/active_link_tags.py
@@ -43,7 +43,8 @@ def active_link(
     if hasattr(request, "resolver_match") and hasattr(request.resolver_match, "kwargs"):
         resolver_kwargs = request.resolver_match.kwargs
 
-    # Use resolver_kwargs as defaults, but explicitly provided kwargs (like pk) take precedence
+    # Use resolver_kwargs as defaults, but explicitly provided kwargs (like pk)
+    # take precedence
     kwargs = {**resolver_kwargs, **kwargs}
 
     active = False

--- a/tests/templates/detailed_action_kwargs_multiple_specific.html
+++ b/tests/templates/detailed_action_kwargs_multiple_specific.html
@@ -1,0 +1,15 @@
+{% load active_link_tags %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Multiple specific links test</title>
+</head>
+<body>
+    <div id="link-pk-1" class="{% active_link 'detailed-action-multiple-specific' pk=1 %}">Link to pk=1</div>
+    <div id="link-pk-2" class="{% active_link 'detailed-action-multiple-specific' pk=2 %}">Link to pk=2</div>
+    <div id="link-pk-3" class="{% active_link 'detailed-action-multiple-specific' pk=3 %}">Link to pk=3</div>
+</body>
+</html>
+

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -101,3 +101,23 @@ class TestActiveLink(TestCase):
         # Should render the inactive class without throwing an error
         self.assertIn('class="not-active"', html)
         self.assertNotIn('class="active"', html)
+
+    def test_multiple_links_with_specific_kwargs(self):
+        """
+        Test that multiple active_link tags on the same page with different
+        explicit kwargs are evaluated independently.
+
+        When viewing a page with the URL /detailed/action/multiple-specific/2/,
+        and the page has `active_link` tags for pk=1, pk=2, and pk=3.
+        Only the link with pk=2 should be active. The resolver_kwargs
+        from the current URL should serve as defaults but not override the explicit
+        pk values.
+        """
+        content = self.reverse_helper("detailed-action-multiple-specific", {"pk": 2})
+
+        # Only the link with pk=2 should be active
+        self.assertIn('id="link-pk-2" class="active"', content)
+
+        # Links with pk=1 and pk=3 should NOT be active
+        self.assertNotIn('id="link-pk-1" class="active"', content)
+        self.assertNotIn('id="link-pk-3" class="active"', content)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -108,10 +108,9 @@ class TestActiveLink(TestCase):
         explicit kwargs are evaluated independently.
 
         When viewing a page with the URL /detailed/action/multiple-specific/2/,
-        and the page has `active_link` tags for pk=1, pk=2, and pk=3.
-        Only the link with pk=2 should be active. The resolver_kwargs
-        from the current URL should serve as defaults but not override the explicit
-        pk values.
+        and the page has `active_link` tags for pk=1, pk=2, and pk=3. Only the
+        link with pk=2 should be active. The resolver_kwargs from the current
+        URL should serve as defaults but not override the explicit pk values.
         """
         content = self.reverse_helper("detailed-action-multiple-specific", {"pk": 2})
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -41,4 +41,11 @@ urlpatterns = [
         TemplateView.as_view(template_name="detailed_action_kwargs_multiple.html"),
         name="detailed-action-multiple",
     ),
+    path(
+        r"detailed/action/multiple-specific/<int:pk>/",
+        TemplateView.as_view(
+            template_name="detailed_action_kwargs_multiple_specific.html"
+        ),
+        name="detailed-action-multiple-specific",
+    ),
 ]


### PR DESCRIPTION
## Problem

There was an issue in the `active_link` template tag where URL parameters from the current request (`resolver_kwargs`) would overwrite explicitly provided kwargs. This caused multiple links with different parameter values to all incorrectly show as active when they appeared on the same page.

### Example

When on a page with a url like `/article/2/`, a sidebar with multiple article links would behave incorrectly:

```django
<a href="{% url 'article-detail' pk=1 %}" class="{% active_link 'article-detail' pk=1 %}">Article 1</a>
<a href="{% url 'article-detail' pk=2 %}" class="{% active_link 'article-detail' pk=2 %}">Article 2</a>
<a href="{% url 'article-detail' pk=3 %}" class="{% active_link 'article-detail' pk=3 %}">Article 3</a>
```

**Expected behavior:** Only Article 2 should have the active class  

**Actual behavior:** All three articles showed as active

## Root Cause

`kwargs.update(resolver_kwargs)` made `resolver_kwargs` (containing `{'pk': 2}` from the current URL) overwrite the explicit `pk` values (1, 2, 3) provided to each `active_link` tag. As a result, all three tags would reverse to `/article/2/` and match the current path, appearing active.

## Solution

This uses resolver_kwargs for defaults, but explicitly provided kwargs take precedence

A new test was added. All tests pass.
